### PR TITLE
Fixed UI not showing if the selected quest's mod wasn't loaded

### DIFF
--- a/scripts/openmw_questmenu/questHandler.lua
+++ b/scripts/openmw_questmenu/questHandler.lua
@@ -27,6 +27,11 @@ end
 
 local function getQuestText(questId, stage)
     local dialogueRecord = core.dialogue.journal.records[questId]
+    
+    -- Triggers if the quest's source mod wasn't loaded
+    if dialogueRecord == nil then
+        return "Error: No information found."
+    end
 
     local filteredDialogue = nil
     for _, dialogue in pairs(dialogueRecord.infos) do


### PR DESCRIPTION
You might want to handle this issue more thoroughly - remove the quest entry from the Quest Menu altogether - but that's up to you to decide. This little edit just fixes prevents UI from borking on existing saves if player doesn't load the mod from which quest is from (either because he forgot to enable it or it was deleted altogether)